### PR TITLE
feat:  adjust use of StackIcon component for appearance, rendering …

### DIFF
--- a/src/components/CardOtherProjects.jsx
+++ b/src/components/CardOtherProjects.jsx
@@ -1,7 +1,7 @@
 import { ReactComponent as Link } from "../assets/icons/link.svg"
 import { ReactComponent as Branch } from "../assets/icons/branch.svg"
-
-export function CardOuthersProjects ({Title, Content, Tech, Github, Site}) {
+import { StackIcon } from 'github-automated-repos/index';
+export function CardOuthersProjects ({Title, Content, Tech, Github, Site, Stacks}) {
   const site = `https://${Site}`
   
   return(
@@ -18,6 +18,15 @@ export function CardOuthersProjects ({Title, Content, Tech, Github, Site}) {
       </div>
 
       <span className= "text-xs text-purple-700 font-thin">{Tech}</span>
+      {Stacks.map((icon) => {
+                  return (
+                    <StackIcon key={icon} iconItem={icon} />
+                  )
+                })}
+
+      
+
+      
     </div>
   )
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -118,6 +118,7 @@ export function Home() {
             Tech={repos.language}
             GitHub={repos.link}
             Site={repos.website}
+            
             />))
           }
 
@@ -135,6 +136,7 @@ export function Home() {
                 Content={reposOther.description}
                 Tech={reposOther.language}
                 Site={reposOther.homepage}
+                Stacks = {reposOther.topics}
               />))
             }
               


### PR DESCRIPTION
Demonstration of using the StackIcon component of the github-automated-repos lib. Technologies are rendered from what is placed in the Topics field within the repository.
Vide: https://github-automated-repos.vercel.app/documentation/stackIcons

![image](https://github.com/Ar3secchim/Project-Portifolio-web/assets/59892368/7b8e247d-b3c3-433f-ba0b-0715ff6222a3)
![image](https://github.com/Ar3secchim/Project-Portifolio-web/assets/59892368/4c0c5e50-3295-489d-8dd2-f6e4ea9f0082)
